### PR TITLE
Fix custom counter and card deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Counter Slayer is a small Svelte / JSCad application to help you build box and t
 - Layout individual trays with stacks of counters.
 - Layout stacks as top-loading, edge-crosswise, or edge-lengthwize across a tray.
 - Counters can be custom sized in hex, square, rectangle, circle and triangles.
+- Add playing card trays that support custom sized cards.
 - Generate boxes for groups of trays with "snap to close" lids.
 - Bin-packing autosorts for the counters and trays so you don't need to think too much about layouts.
 - Generate a PDF reference diagram to let you know which counters go in which stack.

--- a/src/lib/components/GlobalsPanel.svelte
+++ b/src/lib/components/GlobalsPanel.svelte
@@ -120,13 +120,15 @@
 				onchange({
 					...params,
 					customShapes: newShapes,
-					topLoadedStacks: params.topLoadedStacks.map(([shape, count]) =>
-						shape === `custom:${oldName}` ? [`custom:${newName}`, count] : [shape, count]
-					),
-					edgeLoadedStacks: params.edgeLoadedStacks.map(([shape, count, orient]) =>
+					topLoadedStacks: params.topLoadedStacks.map(([shape, count, label]) =>
 						shape === `custom:${oldName}`
-							? [`custom:${newName}`, count, orient]
-							: [shape, count, orient]
+							? [`custom:${newName}`, count, label]
+							: [shape, count, label]
+					),
+					edgeLoadedStacks: params.edgeLoadedStacks.map(([shape, count, orient, label]) =>
+						shape === `custom:${oldName}`
+							? [`custom:${newName}`, count, orient, label]
+							: [shape, count, orient, label]
 					)
 				});
 				return;


### PR DESCRIPTION
There was a bug where if you deleted a custom counter, it would change counter stacks not using that counter size to a different counter. This was due to it referencing the counter array index, rather than the name.